### PR TITLE
Proposed to reduce the block generation time to 5 seconds in the morph

### DIFF
--- a/services/morph_chain/protocol.privnet.yml
+++ b/services/morph_chain/protocol.privnet.yml
@@ -1,6 +1,6 @@
 ProtocolConfiguration:
   Magic: 56753
-  SecondsPerBlock: 15
+  SecondsPerBlock: 5
   MemPoolSize: 50000
   StandbyValidators:
     - 02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2


### PR DESCRIPTION
For the convenience of testing, it is proposed to reduce the block generation time to 5 seconds, which will reduce the time for passing the integration tests.