### PR TITLE
Move storage node's shards to external volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,5 +71,15 @@ hosts: vendor/hosts
 
 # Clean-up the envirinment
 .PHONY: clean
+.ONESHELL:
 clean:
 	@rm -rf vendor/*
+	@for svc in $(START_SVCS)
+	do
+		vols=`docker-compose -f services/$${svc}/docker-compose.yml config --volumes`
+		if [[ ! -z "$${vols}" ]]; then
+			for vol in $${vols}; do
+				docker volume rm "$${svc}_$${vol}" 2> /dev/null
+			done
+		fi
+	done

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,16 @@ down:
 	$(foreach SVC, $(STOP_SVCS), $(shell docker-compose -f services/$(SVC)/docker-compose.yml down))
 
 .PHONY: vendor/hosts
+.ONESHELL:
 vendor/hosts:
-	@for file in $(HOSTS_LINES); do \
-		while read h; do \
-			echo $${h}| sed 's|IPV4_PREFIX|$(IPV4_PREFIX)|g' | sed 's|LOCAL_DOMAIN|$(LOCAL_DOMAIN)|g'; \
-		done < $${file}; \
+	@for file in $(HOSTS_LINES)
+	do
+		while read h
+		do
+			echo $${h} | \
+			sed 's|IPV4_PREFIX|$(IPV4_PREFIX)|g' | \
+			sed 's|LOCAL_DOMAIN|$(LOCAL_DOMAIN)|g'
+		done < $${file};
 	done > $@
 
 # Display changes for /etc/hosts

--- a/services/storage/docker-compose.yml
+++ b/services/storage/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     volumes:
       - ./01.key:/01.key
       - ./../../vendor/hosts:/etc/hosts
+      - storage_s01:/storage
     stop_signal: SIGKILL
     env_file: [ ".env", ".storage.env" ]
     environment:
@@ -36,6 +37,7 @@ services:
     volumes:
       - ./02.key:/02.key
       - ./../../vendor/hosts:/etc/hosts
+      - storage_s02:/storage
     stop_signal: SIGKILL
     env_file: [ ".env", ".storage.env" ]
     environment:
@@ -57,6 +59,7 @@ services:
     volumes:
       - ./03.key:/03.key
       - ./../../vendor/hosts:/etc/hosts
+      - storage_s03:/storage
     stop_signal: SIGKILL
     env_file: [ ".env", ".storage.env" ]
     environment:
@@ -78,6 +81,7 @@ services:
     volumes:
       - ./04.key:/04.key
       - ./../../vendor/hosts:/etc/hosts
+      - storage_s04:/storage
     stop_signal: SIGKILL
     env_file: [ ".env", ".storage.env" ]
     environment:
@@ -85,6 +89,12 @@ services:
       - NEOFS_NODE_ADDRESS=s04.${LOCAL_DOMAIN}:8080
       - NEOFS_GRPC_ENDPOINT=s04.${LOCAL_DOMAIN}:8080
       - NEOFS_NODE_ATTRIBUTE_0=/Location:Europe/Country:Finalnd/City:Helsinki
+
+volumes:
+  storage_s01:
+  storage_s02:
+  storage_s03:
+  storage_s04:
 
 networks:
   storage_int:


### PR DESCRIPTION
Closes: #33

Used Docker volumes instead of bind-mounts to prevent permission issues.