### PR TITLE
Use /usr/bin/env instead of /bin/bash

### DIFF
--- a/bin/deposit.sh
+++ b/bin/deposit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Source env settigns
 . .env


### PR DESCRIPTION
Signed-off-by: Evgeniy Kulikov <kim@nspcc.ru>