### PR TITLE
[#77] http_gate: update version to 0.15.0

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ NODE_VERSION=0.19.0
 NODE_IMAGE=nspccdev/neofs-storage
 
 # HTTP Gate
-HTTP_GW_VERSION=0.14.3
+HTTP_GW_VERSION=0.15.0
 HTTP_GW_IMAGE=nspccdev/neofs-http-gate
 
 # S3 Gate

--- a/docs/http_gate.md
+++ b/docs/http_gate.md
@@ -6,7 +6,7 @@ Source code and more information can be found in [project's GitHub repository](h
 
 ## .env settings
 
-### HTTP_GW_VERSION=0.12.0
+### HTTP_GW_VERSION=0.15.0
 
 Image version label to use for containers.
 


### PR DESCRIPTION
Close #77 

Updated version of http_gate component  from 0.14.3 to 0.15.0 in .env and docs files.

Also added an image of http_gate repo v0.15.0 with tag 0.15.0 to [Docker](https://hub.docker.com/repository/docker/nspccdev/neofs-http-gate)

