### PR TITLE
Fix wallets typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Tools to set up local NeoFS network and N3 privnets. Devenv, for short.
 $ make up
 ```
 When all services are up, you need to make GAS deposit for test wallet to be
-able to pay for NeoFS operations. Test wallet is located in `wallet/wallet.json`
-with the corresponding key in `wallet/wallet.key`. The password is empty.
+able to pay for NeoFS operations. Test wallet is located in `wallets/wallet.json`
+with the corresponding key in `wallets/wallet.key`. The password is empty.
 
 ```
 $ make prepare.ir


### PR DESCRIPTION
Changed wallet/wallet.key and wallet/wallet.json to wallets/wallet.key and wallets/wallet.json.

Signed-off-by: EliChin <elizaveta@nspcc.ru>