### PR TITLE
Release/v0.22.2

### DIFF
--- a/.env
+++ b/.env
@@ -11,11 +11,11 @@ NEOGO_VERSION=0.95.3
 MORPH_CHAIN_URL="https://github.com/nspcc-dev/neofs-contract/releases/download/v0.9.2/devenv_sidechain.gz"
 
 # NeoFS InnerRing nodes
-IR_VERSION=0.22.0
+IR_VERSION=0.22.2
 IR_IMAGE=nspccdev/neofs-ir
 
 # NeoFS Storage nodes
-NODE_VERSION=0.22.0
+NODE_VERSION=0.22.2
 NODE_IMAGE=nspccdev/neofs-storage
 
 # HTTP Gate

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ tmp
 .secrets
 sites/*
 !sites/.gitkeep
+services/storage/*tls.crt
+services/storage/*tls.key


### PR DESCRIPTION
Update `neofs-node` to `v0.22.2`. Add generated TLS certs to gitignore.