### PR TITLE
changed `docker exec` to non-interactive on testinvokefunction

### DIFF
--- a/bin/tick.sh
+++ b/bin/tick.sh
@@ -6,6 +6,9 @@
 
 # NeoGo binary path.
 NEOGO="${NEOGO:-docker exec -it main_chain neo-go}"
+# Launching neo-go this way is useful, when running the script not from
+# terminal, for instance, in jenkins job.
+NEOGO_NONINTERACTIVE="${NEOGO_NONINTERACTIVE:-docker exec main_chain neo-go}"
 
 # Wallet files to change config value
 WALLET="${WALLET:-services/chain/node-wallet.json}"
@@ -18,7 +21,7 @@ PASSWD="one"
 ADDR=`cat ${WALLET} | jq -r .accounts[2].address`
 
 # Fetch current epoch value
-EPOCH=`${NEOGO} contract testinvokefunction -r \
+EPOCH=`${NEOGO_NONINTERACTIVE} contract testinvokefunction -r \
 http://morph_chain.${LOCAL_DOMAIN}:30333 \
 ${NEOFS_IR_CONTRACTS_NETMAP} \
 epoch | grep 'value' | awk -F'"' '{ print $4 }'`


### PR DESCRIPTION
When running dev-env not from terminal, for instance, from a jenkins job, some commands which expect terminal interactions behave oddly. This fix makes neofs-dev-env more friendly for automation.

Related [PR](https://github.com/nspcc-dev/pipelines/pull/31) into the pipelines
Related testcases [issue](https://github.com/nspcc-dev/neofs-testcases/issues/67)

