### PR TITLE
add sleep for one morph block time on tick new epoch

### DIFF
--- a/bin/tick.sh
+++ b/bin/tick.sh
@@ -24,6 +24,10 @@ else
   ADDR=`cat ${WALLET} | jq -r .accounts[0].address`
 fi
 
+# Grep Morph block time
+SIDECHAIN_PROTO="${SIDECHAIN_PROTO:-services/morph_chain/protocol.privnet.yml}"
+BLOCK_DURATION=`grep SecondsPerBlock < $SIDECHAIN_PROTO | awk '{print $2}'`
+
 # Fetch current epoch value
 EPOCH=`${NEOGO_NONINTERACTIVE} contract testinvokefunction -r \
 http://morph_chain.${LOCAL_DOMAIN}:30333 \
@@ -37,3 +41,6 @@ echo "Updating NeoFS epoch to $((EPOCH+1))"
 -r http://morph_chain.${LOCAL_DOMAIN}:30333 \
 ${NEOFS_IR_CONTRACTS_NETMAP} \
 newEpoch int:$((EPOCH+1)) -- ${ADDR}:Global
+
+# Wait one Morph block to ensure the transaction broadcasted
+sleep $BLOCK_DURATION


### PR DESCRIPTION
I use dev-env with automation and update its configuration, which requires ticking new epoch. Sometimes I expirience the tick fail, because transaction haven't broadcasted in morph_chain yet. For instance
```
~/neofs-dev-env$ make up ; make update.max_object_size val=1000
Pulling basenet ... done
Pulling neofs_main_chain ... done

...

http_gate is up-to-date
s3_gate is up-to-date
Updating NeoFS epoch to 7
Enter account NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP password > 
Sent invocation transaction 01839eadbc98a7ba98388d56231e9372b61043701499771b6cbabb8b0a6ed864
NeoFS Developer Environment is ready
Changing MaxObjectSize configration value to 1000
Enter account NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP password > 
Sent invocation transaction 099aa4e26369b274eefa00d6e73df355e3d51d7c3f54a16f16301d0b6f8c1215
Updating NeoFS epoch to 7
Enter account NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP password > 
Warning: FAULT VM state returned from the RPC node: at instruction 3149 (THROW): unhandled exception: "invalid epoch"
. Use --force flag to send the transaction anyway.
neofs_config.mk:7: recipe for target 'update.max_object_size' failed
make: *** [update.max_object_size] Error 1
```

Added sleep for one block period to avoid such cases.