### PR TITLE
Add NNS resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Make sure you have installed all of the following prerequisites on your machine:
 * expect
 * openssl
 * jq
+* base64 (coreutils)
 
 
 ## Quick Start

--- a/bin/config.sh
+++ b/bin/config.sh
@@ -12,6 +12,7 @@ WALLET="${WALLET:-services/chain/node-wallet.json}"
 WALLET_IMG="${WALLET_IMG:-wallets/node-wallet.json}"
 # Wallet password that would be entered automatically; '-' means no password
 PASSWD="one"
+NETMAP_ADDR=`bin/resolve.sh netmap.neofs`
 
 # NeoFS configuration record: key is a string and value is an int
 KEY=${1}
@@ -33,7 +34,7 @@ echo "Changing ${KEY} configration value to ${VALUE}"
 -w ${WALLET_IMG} \
 -a ${ADDR} \
 -r http://morph_chain.${LOCAL_DOMAIN}:30333 \
-${NEOFS_IR_CONTRACTS_NETMAP} \
+${NETMAP_ADDR} \
 setConfig bytes:beefcafe \
 string:${KEY} \
 int:${VALUE} -- ${ADDR} || exit 1

--- a/bin/resolve.sh
+++ b/bin/resolve.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Source env settings
+. .env
+
+# NeoGo binary path.
+NEOGO="${NEOGO:-docker exec -it morph_chain neo-go}"
+# NNS contract script hash
+NNS_ADDR=`curl -s --data '{ "id": 1, "jsonrpc": "2.0", "method": "getcontractstate", "params": [1] }' http://morph_chain.${LOCAL_DOMAIN}:30333/ | jq -r '.result.hash'`
+
+${NEOGO} contract testinvokefunction \
+-r http://morph_chain.${LOCAL_DOMAIN}:30333 \
+${NNS_ADDR} resolve string:${1} int:16 | jq -r '.stack[0].value' | base64 -d

--- a/bin/tick.sh
+++ b/bin/tick.sh
@@ -27,11 +27,12 @@ fi
 # Grep Morph block time
 SIDECHAIN_PROTO="${SIDECHAIN_PROTO:-services/morph_chain/protocol.privnet.yml}"
 BLOCK_DURATION=`grep SecondsPerBlock < $SIDECHAIN_PROTO | awk '{print $2}'`
+NETMAP_ADDR=`bin/resolve.sh netmap.neofs`
 
 # Fetch current epoch value
 EPOCH=`${NEOGO_NONINTERACTIVE} contract testinvokefunction -r \
 http://morph_chain.${LOCAL_DOMAIN}:30333 \
-${NEOFS_IR_CONTRACTS_NETMAP} \
+${NETMAP_ADDR} \
 epoch | grep 'value' | awk -F'"' '{ print $4 }'`
 
 echo "Updating NeoFS epoch to $((EPOCH+1))"
@@ -39,7 +40,7 @@ echo "Updating NeoFS epoch to $((EPOCH+1))"
 -w ${WALLET_IMG} \
 -a ${ADDR} \
 -r http://morph_chain.${LOCAL_DOMAIN}:30333 \
-${NEOFS_IR_CONTRACTS_NETMAP} \
+${NETMAP_ADDR} \
 newEpoch int:$((EPOCH+1)) -- ${ADDR}:Global
 
 # Wait one Morph block to ensure the transaction broadcasted


### PR DESCRIPTION
This PR adds script that resolves TXT records from NNS contract. NNS contract stores side chain contract addresses as hex encoded little endian strings.

Available NNS records:
- alphabet0.neofs
- audit.neofs
- balance.neofs
- container.neofs
- neofsid.neofs
- netmap.neofs
- reputation.neofs
- proxy.neofs

Closes #47