### PR TITLE
Revert "[#141] Update locode_db to `v0.2.0`"

### DIFF
--- a/.env
+++ b/.env
@@ -27,7 +27,7 @@ S3_GW_VERSION=0.17.0
 S3_GW_IMAGE=nspccdev/neofs-s3-gw
 
 # NeoFS LOCODE database
-LOCODE_DB_URL=https://github.com/nspcc-dev/neofs-locode-db/releases/download/v0.2.0/locode_db.gz
+LOCODE_DB_URL=https://github.com/nspcc-dev/neofs-locode-db/releases/download/v0.1.0/locode_db.gz
 #LOCODE_DB_PATH=/path/to/locode_db
 
 # NeoFS CLI binary


### PR DESCRIPTION
This reverts commit 23481920b0ac943483503b8e6214a07201432eee.

`SE STO` is valid LOCODE but it's missing in v0.2.0 because of https://github.com/nspcc-dev/neofs-locode-db/issues/3
Thus we can't use it right now.