### PR TITLE
`Make up/down` for services

### DIFF
--- a/.basic_services
+++ b/.basic_services
@@ -1,0 +1,7 @@
+# Services start/stop order
+# Will start from top to bottom and stop in reverse
+basenet
+chain
+morph_chain
+ir
+storage

--- a/.services
+++ b/.services
@@ -1,10 +1,5 @@
 # Services start/stop order
 # Will start from top to bottom and stop in reverse
-basenet
-chain
-morph_chain
-ir
-storage
 http_gate
 s3_gate
 coredns

--- a/services/s3_gate/docker-compose.yml
+++ b/services/s3_gate/docker-compose.yml
@@ -2,7 +2,7 @@
 
 version: "2.4"
 services:
-  http_gate:
+  s3_gate:
     image: ${S3_GW_IMAGE}:${S3_GW_VERSION}
     domainname: ${LOCAL_DOMAIN}
     hostname: s3_gate


### PR DESCRIPTION
- `make up.basic` builds up basic neofs
- `make up.service` needs `val=s3_gate\http_gate\coredns` par to build up certain service
- `make down.service` needs `val=s3_gate\http_gate\coredns` par to stop certain service
- in `services/s3_gate/docker-compose.yml` name of the service changed to the relevant one

#154 
Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>