### PR TITLE
Add .env.int_test files for config amendments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,8 @@ hosts: vendor/hosts
 .ONESHELL:
 clean:
 	@rm -rf vendor/* services/storage/s04tls.* services/nats/*.pem
-	@for svc in $(START_SVCS)
+	@> .int_test.env
+	@for svc in $(PULL_SVCS)
 	do
 		vols=`docker-compose -f services/$${svc}/docker-compose.yml config --volumes`
 		if [[ ! -z "$${vols}" ]]; then

--- a/services/basenet/.int_test.env
+++ b/services/basenet/.int_test.env
@@ -1,0 +1,1 @@
+../../.int_test.env

--- a/services/basenet/docker-compose.yml
+++ b/services/basenet/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     command: ["/bin/sleep", "infinity"]
     restart: always
     stop_signal: SIGKILL
+    env_file: [ ".int_test.env" ]
     environment:
       - TZ=Etc/UTC
     networks:

--- a/services/chain/.int_test.env
+++ b/services/chain/.int_test.env
@@ -1,0 +1,1 @@
+../../.int_test.env

--- a/services/chain/docker-compose.yml
+++ b/services/chain/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       internet:
         ipv4_address: ${IPV4_PREFIX}.50
     stop_signal: SIGKILL
+    env_file: [ ".int_test.env" ]
     environment:
     - ACC=/chain.gz
     volumes:

--- a/services/coredns/.int_test.env
+++ b/services/coredns/.int_test.env
@@ -1,0 +1,1 @@
+../../.int_test.env

--- a/services/coredns/docker-compose.yml
+++ b/services/coredns/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       internet:
         ipv4_address: ${IPV4_PREFIX}.53
     stop_signal: SIGKILL
+    env_file: [ ".int_test.env" ]
     volumes:
       - ./Corefile:/Corefile
       - ./../../vendor/hosts:/etc/hosts

--- a/services/http_gate/.int_test.env
+++ b/services/http_gate/.int_test.env
@@ -1,0 +1,1 @@
+../../.int_test.env

--- a/services/http_gate/docker-compose.yml
+++ b/services/http_gate/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./wallet.json:/wallet.json
       - ./../../vendor/hosts:/etc/hosts
     stop_signal: SIGKILL
-    env_file: [ ".env", ".http.env" ]
+    env_file: [ ".env", ".http.env", ".int_test.env" ]
     environment:
       - HTTP_GW_WALLET=/wallet.json
       - HTTP_GW_WALLET_PASSPHRASE=one

--- a/services/ir/.int_test.env
+++ b/services/ir/.int_test.env
@@ -1,0 +1,1 @@
+../../.int_test.env

--- a/services/ir/docker-compose.yml
+++ b/services/ir/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./../../vendor/locode_db:/locode/db
       - ./../../vendor/neofs-cli:/neofs-cli
       - ./healthcheck.sh:/healthcheck.sh
-    env_file: [ ".env", ".ir.env" ]
+    env_file: [ ".env", ".ir.env", ".int_test.env" ]
     environment:
     - NEOFS_IR_WALLET_PATH=/wallet.json
     - NEOFS_IR_WALLET_ADDRESS=Nhfg3TbpwogLvDGVvAvqyThbsHgoSUKwtn

--- a/services/morph_chain/.int_test.env
+++ b/services/morph_chain/.int_test.env
@@ -1,0 +1,1 @@
+../../.int_test.env

--- a/services/morph_chain/docker-compose.yml
+++ b/services/morph_chain/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       internet:
         ipv4_address: ${IPV4_PREFIX}.90
     stop_signal: SIGKILL
+    env_file: [ ".int_test.env" ]
     environment:
     - ACC=/morph_chain.gz
     volumes:

--- a/services/nats/.int_test.env
+++ b/services/nats/.int_test.env
@@ -1,0 +1,1 @@
+../../.int_test.env

--- a/services/nats/docker-compose.yml
+++ b/services/nats/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./server-key.pem:/certs/server-key.pem
       - ./ca-cert.pem:/certs/ca-cert.pem
     stop_signal: SIGKILL
-    env_file: [ ".env" ]
+    env_file: [ ".env", ".int_test.env" ]
     command: ["-c", "/etc/nats/neofs-nats-server.conf"]
 
 networks:

--- a/services/s3_gate/.int_test.env
+++ b/services/s3_gate/.int_test.env
@@ -1,0 +1,1 @@
+../../.int_test.env

--- a/services/s3_gate/docker-compose.yml
+++ b/services/s3_gate/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ./tls.crt:/tls.crt
       - ./../../vendor/hosts:/etc/hosts
     stop_signal: SIGKILL
-    env_file: [ ".env", ".s3.env" ]
+    env_file: [ ".env", ".s3.env", ".int_test.env" ]
     environment:
       - S3_GW_WALLET=/wallet.json
       - S3_GW_WALLET_PASSPHRASE=s3

--- a/services/storage/.int_test.env
+++ b/services/storage/.int_test.env
@@ -1,0 +1,1 @@
+../../.int_test.env

--- a/services/storage/docker-compose.yml
+++ b/services/storage/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ./healthcheck.sh:/healthcheck.sh
       - ./s04tls.crt:/etc/ssl/certs/s04tls.crt
     stop_signal: SIGKILL
-    env_file: [ ".env", ".storage.env" ]
+    env_file: [ ".env", ".storage.env", ".int_test.env" ]
     environment:
       - NEOFS_NODE_KEY=/01.key
       - NEOFS_NODE_ADDRESSES=s01.${LOCAL_DOMAIN}:8080
@@ -53,7 +53,7 @@ services:
       - ./healthcheck.sh:/healthcheck.sh
       - ./s04tls.crt:/etc/ssl/certs/s04tls.crt
     stop_signal: SIGKILL
-    env_file: [ ".env", ".storage.env" ]
+    env_file: [ ".env", ".storage.env", ".int_test.env" ]
     environment:
       - NEOFS_NODE_KEY=/02.key
       - NEOFS_NODE_ADDRESSES=s02.${LOCAL_DOMAIN}:8080
@@ -86,7 +86,7 @@ services:
       - ./healthcheck.sh:/healthcheck.sh
       - ./s04tls.crt:/etc/ssl/certs/s04tls.crt
     stop_signal: SIGKILL
-    env_file: [ ".env", ".storage.env" ]
+    env_file: [ ".env", ".storage.env", ".int_test.env" ]
     environment:
       - NEOFS_NODE_KEY=/03.key
       - NEOFS_NODE_ADDRESSES=s03.${LOCAL_DOMAIN}:8080
@@ -120,7 +120,7 @@ services:
       - ./s04tls.crt:/tls.crt
       - ./s04tls.key:/tls.key
     stop_signal: SIGKILL
-    env_file: [ ".env", ".storage.env" ]
+    env_file: [ ".env", ".storage.env", ".int_test.env" ]
     environment:
       - NEOFS_NODE_KEY=/04.key
       - NEOFS_NODE_ADDRESSES=s04.${LOCAL_DOMAIN}:8080 grpcs://s04.${LOCAL_DOMAIN}:8082


### PR DESCRIPTION
For executing [GAS Emission test](https://github.com/nspcc-dev/neofs-testcases/issues/41) we need to set env var `NEOFS_IR_EMIT_GAS_BALANCE_THRESHOLD` inside IR container, which can be done through amendments in an .env file only. In order not to amend existing .env files, it was decided to create separate files of this kind (`.env.int_test`) for each service. They are empty by default and always cleared during `make clean`.
Also `make clean` fixed to clean all services, not only $(START_SVCS).

Signed-off-by: Elizaveta Chichindaeva <elizaveta@nspcc.ru>