### PR TITLE
.env: use neofs-node that supports neofs-contract v0.15.x

### DIFF
--- a/.env
+++ b/.env
@@ -11,11 +11,11 @@ NEOGO_VERSION=0.98.1
 MORPH_CHAIN_URL="https://github.com/nspcc-dev/neofs-contract/releases/download/v0.15.0/devenv_sidechain.gz"
 
 # NeoFS InnerRing nodes
-IR_VERSION=0.28.0-rc.1
+IR_VERSION=0.28.0-rc.2
 IR_IMAGE=nspccdev/neofs-ir
 
 # NeoFS Storage nodes
-NODE_VERSION=0.28.0-rc.1
+NODE_VERSION=0.28.0-rc.2
 NODE_IMAGE=nspccdev/neofs-storage
 
 # NATS Server
@@ -39,5 +39,5 @@ LOCODE_DB_URL=https://github.com/nspcc-dev/neofs-locode-db/releases/download/v0.
 #LOCODE_DB_PATH=/path/to/locode_db
 
 # NeoFS CLI binary
-NEOFS_CLI_URL=https://github.com/nspcc-dev/neofs-node/releases/download/v0.28.0-rc.1/neofs-cli-amd64.tar.gz
+NEOFS_CLI_URL=https://github.com/nspcc-dev/neofs-node/releases/download/v0.28.0-rc.2/neofs-cli-amd64.tar.gz
 #NEOFS_CLI_PATH=/path/to/neofs-cli-binary


### PR DESCRIPTION
Signed-off-by: Alex Vanin <alexey@nspcc.ru>