### PR TITLE
Doc/Add `make` minimum version required

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Tools to set up local NeoFS network and N3 privnets. Devenv, for short.
 Make sure you have installed all of the following prerequisites on your machine:
 * docker
 * docker-compose
-* make
+* make (`3.82+`)
 * expect
 * openssl
 * jq


### PR DESCRIPTION
Makefile contains `.ONESHELL` that is supported only in `3.82+`.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Related to #198.