### PR TITLE
services/storage: determine certificate presence at runtime

### DIFF
--- a/services/storage/artifacts.mk
+++ b/services/storage/artifacts.mk
@@ -1,6 +1,7 @@
 # Create new tls certs
 
-STORAGE_DIR=$(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+CURRENT_DIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+STORAGE_DIR=$(patsubst %/,%,$(CURRENT_DIR))
 SSL_CONFIG := $(shell mktemp)
 
 get.storage:
@@ -10,8 +11,10 @@ get.storage:
       echo "req_extensions=san"; \
       echo "[san]"; \
       echo "subjectAltName=DNS:s04.${LOCAL_DOMAIN}") > ${SSL_CONFIG}
-ifeq ($(shell ! test -e ${STORAGE_DIR}/s04tls.key && echo -n yes),yes)
-	@openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes \
-    		-subj "/C=RU/ST=SPB/L=St.Petersburg/O=NSPCC/OU=NSPCC/CN=s04.${LOCAL_DOMAIN}" \
-    		-keyout ${STORAGE_DIR}/s04tls.key -out ${STORAGE_DIR}/s04tls.crt -extensions san -config ${SSL_CONFIG}
-endif
+	@echo $(test -e "${STORAGE_DIR}/s04tls.key" && echo true)
+	@if [ ! -e "${STORAGE_DIR}/s04tls.key" ]; then \
+		openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes \
+		-subj "/C=RU/ST=SPB/L=St.Petersburg/O=NSPCC/OU=NSPCC/CN=s04.${LOCAL_DOMAIN}" \
+		-keyout "${STORAGE_DIR}/s04tls.key" -out "${STORAGE_DIR}/s04tls.crt" \
+		-extensions san -config "${SSL_CONFIG}" ; \
+		fi


### PR DESCRIPTION
`ifeq` executes during parsing, because of this `make down clean up`
doesn't work as expected.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>