### PR TITLE
Feat/Add VSCode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,18 @@
+# IDE
 .idea
+.vscode
+
+# Vendoring
 vendor
+
+temp
 tmp
+
 .secrets
 sites/*
 !sites/.gitkeep
+
+# Runtime generation keys
 services/storage/*tls.crt
 services/storage/*tls.key
 services/nats/*.pem


### PR DESCRIPTION
We already have devs with `VSCode`. Comments were taken from the `neofs-node` repo. 