### PR TITLE
storage: Increase healthcheck intervals and timeouts

### DIFF
--- a/services/storage/docker-compose.yml
+++ b/services/storage/docker-compose.yml
@@ -35,10 +35,10 @@ services:
       - NEOFS_NODE_ATTRIBUTE_2=Price:22
     healthcheck:
       test: ["CMD-SHELL", "/healthcheck.sh"]
-      interval: 2s
-      timeout: 1s
+      interval: 5s
+      timeout: 5s
       retries: 5
-      start_period: 10s
+      start_period: 20s
 
   storage02:
     image: ${NODE_IMAGE}:${NODE_VERSION}
@@ -73,10 +73,10 @@ services:
       - NEOFS_NODE_ATTRIBUTE_2=Price:33
     healthcheck:
       test: ["CMD-SHELL", "/healthcheck.sh"]
-      interval: 2s
-      timeout: 1s
+      interval: 5s
+      timeout: 5s
       retries: 5
-      start_period: 10s
+      start_period: 20s
 
   storage03:
     image: ${NODE_IMAGE}:${NODE_VERSION}
@@ -111,10 +111,10 @@ services:
       - NEOFS_NODE_ATTRIBUTE_2=Price:11
     healthcheck:
       test: ["CMD-SHELL", "/healthcheck.sh"]
-      interval: 2s
-      timeout: 1s
+      interval: 5s
+      timeout: 5s
       retries: 5
-      start_period: 10s
+      start_period: 20s
 
   storage04:
     image: ${NODE_IMAGE}:${NODE_VERSION}
@@ -155,10 +155,10 @@ services:
       - NEOFS_NODE_ATTRIBUTE_2=Price:44
     healthcheck:
       test: ["CMD-SHELL", "/healthcheck.sh"]
-      interval: 2s
-      timeout: 1s
+      interval: 5s
+      timeout: 5s
       retries: 5
-      start_period: 10s
+      start_period: 20s
 
   sn-healthcheck:
     container_name: sn-healthcheck


### PR DESCRIPTION
Temporarily adjust healthcheck settings in docker-compose file to mitigate issue #2215, until a root cause is found and resolved. Changes include:
- Increase interval from 2s to 5s
- Increase timeout from 1s to 5s
- Increase start_period from 10s to 20s

Refs: https://github.com/nspcc-dev/neofs-node/issues/2215