### PR TITLE
Certs path

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # Basenet settings
 LOCAL_DOMAIN=neofs.devenv
 IPV4_PREFIX=192.168.130
-CA_CERTS_TRUSTED_STORE=/etc/ssl/certs
+CA_CERTS_TRUSTED_STORE=./vendor/certs
 
 # Bastion image
 BASTION_VERSION=10

--- a/Makefile
+++ b/Makefile
@@ -245,12 +245,7 @@ prepare-test-env:
 	$(MAKE) prepare.ir; \
 	sleep 10; \
 
-	if sudo -n true 2>/dev/null; then \
-		echo "Step 5: Preparing the storage service (with sudo)..."; \
-		sudo $(MAKE) prepare.storage; \
-	else \
-		echo "Step 5: Preparing the storage service (with sudo, you may need to enter your password)..."; \
-		sudo $(MAKE) prepare.storage; \
-	fi; \
+	echo "Step 5: Preparing the storage service..."; \
+	$(MAKE) prepare.storage; \
 
 	echo "Test environment setup completed."

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ variable). This step is required for client services (neofs-http-gw,
 neofs-s3-gw) to interact with the node:
 
 ```
-$ sudo make prepare.storage
+$ make prepare.storage
 ```
 
 Change NeoFS global configuration values with `make update.*` commands. The
@@ -175,34 +175,6 @@ are correct.
 ```bash
 make prepare-test-env
 ```
-
-If you need to enter your password for sudo when running `make prepare-test-env`, the script will wait for you
-to input the password in the terminal.
-Enter your password, and the execution will continue.
-
-However, if you don't want to enter your password every time, you can configure sudo not to ask for a password
-for a specific command or for your user.
-You can add the following line to the `/etc/sudoers` file, using the `sudo visudo` command:
-
-```bash
-your_username ALL=(ALL) NOPASSWD: /path/to/your/make
-```
-
-Replace `your_username` with your actual username and `/path/to/your/make` with the path to the make executable
-on your computer.
-You can find the path to make by running the `which make` command.
-This setting will allow you to run the make command using sudo without entering a password.
-
-If you want to allow running all commands without entering a password for your user, use the following entry:
-
-```bash
-your_username ALL=(ALL) NOPASSWD: ALL
-```
-
-**Note**: Changing sudo settings may increase the security risk for your system,
-especially if you allow running all commands without a password.
-Use this option only if you are aware of the possible risks and are willing to accept them.
-
 
 ## Contributing
 

--- a/bin/addCert.sh
+++ b/bin/addCert.sh
@@ -3,4 +3,5 @@
 # Source env settings
 . .env
 
+mkdir -p "${CA_CERTS_TRUSTED_STORE}"
 ln -sf "$(pwd)/services/storage/s04tls.crt" "${CA_CERTS_TRUSTED_STORE}/s04.${LOCAL_DOMAIN}.tls.crt"


### PR DESCRIPTION
Moves the trusted certificate store from /etc/ssl/certs to /tmp and remove use of sudo when running prepare.storage.

You can see the test result here:
https://github.com/vvarg229/neofs-node/actions/runs/4802101241/jobs/8545463332