### PR TITLE
Makefile: configure MaxObjectSize of 1024 for test env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ prepare-test-env:
 
 	echo "Step 1: Setting up the test environment..."; \
 	$(MAKE) up; \
+	./bin/config.sh int MaxObjectSize 1024; \
 	echo "Waiting a few seconds..."; \
 	sleep 30; \
 


### PR DESCRIPTION
Large objects are defined as this for tests:
```
  def complex_object_size(max_object_size: int) -> int:
      return max_object_size * int(COMPLEX_OBJECT_CHUNKS_COUNT) + int(COMPLEX_OBJECT_TAIL_SIZE)
```
max_object_size is taken from the network settings which by default is 64M. This means that the default large object size is 201327592 or ~200M. And it's not really needed to test split object functionality, this just wastes some time and resources for no good reason. 1K is enough here.