### PR TITLE
ir,storage: Make healthcheck output visible in `docker inspect`

### DIFF
--- a/services/ir/healthcheck.sh
+++ b/services/ir/healthcheck.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 
-/neofs-cli control healthcheck -c /cli-cfg.yml \
-	--endpoint "$NEOFS_IR_CONTROL_GRPC_ENDPOINT" \
-	--ir |
-	grep "Health status: READY"
+out=$(/neofs-cli control healthcheck -c /cli-cfg.yml \
+      	--endpoint "$NEOFS_IR_CONTROL_GRPC_ENDPOINT" \
+      	--ir)
+
+echo "$out"
+
+if [[ "$out" == *"Health status: READY"* ]]; then
+  exit 0
+else
+   exit 1
+fi

--- a/services/storage/healthcheck.sh
+++ b/services/storage/healthcheck.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
-/neofs-cli control healthcheck -c /cli-cfg.yml \
-	--endpoint "$NEOFS_CONTROL_GRPC_ENDPOINT" |
-	grep "Health status: READY"
+out=$(/neofs-cli control healthcheck -c /cli-cfg.yml \
+      	--endpoint "$NEOFS_CONTROL_GRPC_ENDPOINT")
+
+echo "$out"
+
+if [[ "$out" == *"Health status: READY"* ]]; then
+  exit 0
+else
+   exit 1
+fi


### PR DESCRIPTION
Healthcheck commands of `ir` and `storage` service containers execute `neofs-cli control healthcheck`. Previously, exec results were just grep-ed. If output didn't contain particular string, health state log exit code was 1 with empty output. This did not allow to find out what exactly was output by the command. To make it easier to detect problems, the output should be stored regardless of the return code.

```
$ docker inspect --format "{{json .State.Health }}" s01 | jq
```
Before:
```json
{
  "Status": "unhealthy",
  "FailingStreak": 1,
  "Log": [
    {
      "Start": "2023-08-08T12:14:31.525815071+04:00",
      "End": "2023-08-08T12:14:33.074067267+04:00",
      "ExitCode": 1,
      "Output": ""
    }
  ]
}
```
Now:
```json
{
  "Status": "unhealthy",
  "FailingStreak": 1,
  "Log": [
    {
      "Start": "2023-08-08T12:14:31.525815071+04:00",
      "End": "2023-08-08T12:14:33.074067267+04:00",
      "ExitCode": 1,
      "Output": "Network status: OFFLINE\nHealth status: STARTING\n"
    }
  ]
}
```

---

* maybe conflicts with #272  