### PR TITLE
env, services: Add flag to enable metabase resync

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,9 @@ CA_CERTS_TRUSTED_STORE=./vendor/certs
 BASTION_VERSION=10
 BASTION_IMAGE=debian
 
+# Flag to enable metabase resync on start
+RESYNC_METABASE=false
+
 # NeoGo privnet
 #CHAIN_PATH="/path/to/devenv.dump.gz"
 CHAIN_URL="https://github.com/nspcc-dev/neofs-contract/releases/download/v0.17.0/devenv_mainchain.gz"

--- a/services/storage/docker-compose.yml
+++ b/services/storage/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - NEOFS_CONTROL_GRPC_ENDPOINT=${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_1}
       - NEOFS_NODE_ATTRIBUTE_0=UN-LOCODE:RU MOW
       - NEOFS_NODE_ATTRIBUTE_1=Price:22
+      - NEOFS_STORAGE_SHARD_0_RESYNC_METABASE=${RESYNC_METABASE}
+      - NEOFS_STORAGE_SHARD_1_RESYNC_METABASE=${RESYNC_METABASE}
     healthcheck:
       test: ["CMD", "/neofs-cli", "control", "healthcheck", "-c", "/cli-cfg.yml", "--endpoint", "${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_1}"]
       interval: 5s
@@ -62,6 +64,8 @@ services:
       - ../nats/client-key.pem:/etc/neofs-node/nats.tls.key
       - ../nats/ca-cert.pem:/etc/neofs-node/nats.ca.crt
       - ./cfg:/etc/neofs/storage
+      - NEOFS_STORAGE_SHARD_0_RESYNC_METABASE=${RESYNC_METABASE}
+      - NEOFS_STORAGE_SHARD_1_RESYNC_METABASE=${RESYNC_METABASE}
     stop_signal: SIGKILL
     env_file: [ ".env", ".storage.env", ".int_test.env" ]
     command: [ "neofs-node", "--config", "/etc/neofs/storage/config.yml" ]
@@ -112,6 +116,8 @@ services:
       - NEOFS_CONTROL_GRPC_ENDPOINT=${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_3}
       - NEOFS_NODE_ATTRIBUTE_0=UN-LOCODE:SE STO
       - NEOFS_NODE_ATTRIBUTE_1=Price:11
+      - NEOFS_STORAGE_SHARD_0_RESYNC_METABASE=${RESYNC_METABASE}
+      - NEOFS_STORAGE_SHARD_1_RESYNC_METABASE=${RESYNC_METABASE}
     healthcheck:
       test: ["CMD", "/neofs-cli", "control", "healthcheck", "-c", "/cli-cfg.yml", "--endpoint", "${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_3}"]
       interval: 5s
@@ -157,6 +163,8 @@ services:
       - NEOFS_GRPC_1_TLS_KEY=/tls.key
       - NEOFS_NODE_ATTRIBUTE_0=UN-LOCODE:FI HEL
       - NEOFS_NODE_ATTRIBUTE_1=Price:44
+      - NEOFS_STORAGE_SHARD_0_RESYNC_METABASE=${RESYNC_METABASE}
+      - NEOFS_STORAGE_SHARD_1_RESYNC_METABASE=${RESYNC_METABASE}
     healthcheck:
       test: ["CMD", "/neofs-cli", "control", "healthcheck", "-c", "/cli-cfg.yml", "--endpoint", "${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_4}"]
       interval: 5s


### PR DESCRIPTION
Add flag to enable metabase resync on start.
This flag will be false by default and will not change the behavior of the system in any way.
These changes are needed for system tests, tests will change the RESYNC_METABASE flag.
https://github.com/nspcc-dev/neofs-testcases/issues/556

See also:
https://github.com/nspcc-dev/neofs-node/pull/2537