### PR TITLE
.github: Remove flag RESYNC_METABASE

### DIFF
--- a/.env
+++ b/.env
@@ -7,9 +7,6 @@ CA_CERTS_TRUSTED_STORE=${PWD}/vendor/certs
 BASTION_VERSION=10
 BASTION_IMAGE=debian
 
-# Flag to enable metabase resync on start
-RESYNC_METABASE=false
-
 # NeoGo privnet
 #CHAIN_PATH="/path/to/devenv.dump.gz"
 CHAIN_URL="https://github.com/nspcc-dev/neofs-contract/releases/download/v0.17.0/devenv_mainchain.gz"

--- a/services/storage/docker-compose.yml
+++ b/services/storage/docker-compose.yml
@@ -34,8 +34,6 @@ services:
       - NEOFS_CONTROL_GRPC_ENDPOINT=${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_1}
       - NEOFS_NODE_ATTRIBUTE_0=UN-LOCODE:RU MOW
       - NEOFS_NODE_ATTRIBUTE_1=Price:22
-      - NEOFS_STORAGE_SHARD_0_RESYNC_METABASE=${RESYNC_METABASE}
-      - NEOFS_STORAGE_SHARD_1_RESYNC_METABASE=${RESYNC_METABASE}
     healthcheck:
       test: ["CMD", "/neofs-cli", "control", "healthcheck", "-c", "/cli-cfg.yml", "--endpoint", "${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_1}"]
       interval: 5s
@@ -75,8 +73,6 @@ services:
       - NEOFS_CONTROL_GRPC_ENDPOINT=${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_2}
       - NEOFS_NODE_ATTRIBUTE_0=UN-LOCODE:RU LED
       - NEOFS_NODE_ATTRIBUTE_1=Price:33
-      - NEOFS_STORAGE_SHARD_0_RESYNC_METABASE=${RESYNC_METABASE}
-      - NEOFS_STORAGE_SHARD_1_RESYNC_METABASE=${RESYNC_METABASE}
     healthcheck:
       test: ["CMD", "/neofs-cli", "control", "healthcheck", "-c", "/cli-cfg.yml", "--endpoint", "${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_2}"]
       interval: 5s
@@ -116,8 +112,6 @@ services:
       - NEOFS_CONTROL_GRPC_ENDPOINT=${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_3}
       - NEOFS_NODE_ATTRIBUTE_0=UN-LOCODE:SE STO
       - NEOFS_NODE_ATTRIBUTE_1=Price:11
-      - NEOFS_STORAGE_SHARD_0_RESYNC_METABASE=${RESYNC_METABASE}
-      - NEOFS_STORAGE_SHARD_1_RESYNC_METABASE=${RESYNC_METABASE}
     healthcheck:
       test: ["CMD", "/neofs-cli", "control", "healthcheck", "-c", "/cli-cfg.yml", "--endpoint", "${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_3}"]
       interval: 5s
@@ -163,8 +157,6 @@ services:
       - NEOFS_GRPC_1_TLS_KEY=/tls.key
       - NEOFS_NODE_ATTRIBUTE_0=UN-LOCODE:FI HEL
       - NEOFS_NODE_ATTRIBUTE_1=Price:44
-      - NEOFS_STORAGE_SHARD_0_RESYNC_METABASE=${RESYNC_METABASE}
-      - NEOFS_STORAGE_SHARD_1_RESYNC_METABASE=${RESYNC_METABASE}
     healthcheck:
       test: ["CMD", "/neofs-cli", "control", "healthcheck", "-c", "/cli-cfg.yml", "--endpoint", "${NEOFS_STORAGE_CONTROL_GRPC_ENDPOINT_4}"]
       interval: 5s


### PR DESCRIPTION
This commit rolls back 39f2bcfdbc28b9d46c2cc57553137c36eb898643 It was a mistake to make that change.
Now it is not necessary, https://github.com/nspcc-dev/neofs-testcases/pull/608 allows to do without a separate flag.