### PR TITLE
docs: drop obsolete settings

### DIFF
--- a/docs/morph.md
+++ b/docs/morph.md
@@ -16,14 +16,6 @@ RPC available at `http://morph-chain.neofs.devenv:30333`.
 
 ## .env settings
 
-### MORPH_CHAIN_URL
-
-URL to get side chain dump. Used on artifact get stage.
-
-### MORPH_CHAIN_PATH
-
-Path to get side chain dump. If set, overrides `CHAIN_URL`.
-
 ### NEOGO_VERSION
 
 Version of neo-go docker container for side chain deployment.

--- a/docs/notary.md
+++ b/docs/notary.md
@@ -9,50 +9,8 @@ to do these operations. Notary service calculates the exact amount of GAS
 to execute transaction, therefore operations are cheaper (withdraw fee **with**
 notary is less than 0.5 GAS; withdraw fee **without** notary is up to 7.0 GAS). 
 
-By default, main chain service is running without notary service, and side chain
-running with notary service. However, you can change that in configuration.
-
-# Disable notary service in side chain
-
-To disable notary service in side chain do these steps.
-
-1. Update `.env` and choose notary disabled chain dump for side chain.
-
-```
-MORPH_CHAIN_URL="https://github.com/nspcc-dev/neofs-contract/releases/download/v0.9.0/devenv_sidechain_notary_disabled.gz"
-```
-
-Make sure to update chain dump files with `make get` target.
-
-2. Update `service/morph_chain/protocol.privnet.yml` and disable notary settings
-and state root in header.
-   
-```yaml
-ProtocolConfiguration:
-  StateRootInHeader: false
-  P2PSigExtensions: false
-ApplicationConfiguration:
-  P2PNotary:
-    Enabled: false
-```
-
-Chain dump without notary service does not have predefined network map.
-Therefore, you need to wait about 5 minutes until new epoch tick with updated
-network map.
-
-
-3. Enable helper commands
-
-To enable helper commands such as `make tick.epoch` or `make update.epoch_duration`
-make sure to export non-empty `NEOFS_NOTARY_DISABLED` environment variable. 
-```
-$ export NEOFS_NOTARY_DISABLED=1
-```
-
-Use `unset` command to return it back.
-```
-$ unset NEOFS_NOTARY_DISABLED
-```
+By default, main chain service is running without notary service. However, you
+can change that in configuration.
 
 # Enable notary service in main chain
 


### PR DESCRIPTION
MORPCH_CHAIN_* are not used since aacbb8f82f4bafc2f7e8f3ef485a7b99eeb8e4d2 and notary can't be disabled in the sidechain.