### PR TITLE
env: upgrade NeoGo to 0.104.0

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ BASTION_IMAGE=debian
 CHAIN_URL="https://github.com/nspcc-dev/neofs-contract/releases/download/v0.17.0/devenv_mainchain.gz"
 
 #NEOGO
-NEOGO_VERSION=0.102.0
+NEOGO_VERSION=0.104.0
 NEOGO_IMAGE=nspccdev/neo-go
 #NEO_GO_PLATFORM=linux-amd64
 #NEO_GO_URL=https://github.com/nspcc-dev/neo-go/releases/download/v${NEOGO_VERSION}/neo-go-${NEO_GO_PLATFORM}

--- a/services/chain/protocol.privnet.yml
+++ b/services/chain/protocol.privnet.yml
@@ -43,9 +43,11 @@ ApplicationConfiguration:
     Addresses:
       - ":20011"
     Enabled: true
-  UnlockWallet:
-    Path: "./wallets/node-wallet.json"
-    Password: "one"
+  Consensus:
+    Enabled: true
+    UnlockWallet:
+      Path: "./wallets/node-wallet.json"
+      Password: "one"
   Oracle:
     Enabled: true
     NeoFS:

--- a/services/morph_chain/protocol.privnet.yml
+++ b/services/morph_chain/protocol.privnet.yml
@@ -49,6 +49,8 @@ ApplicationConfiguration:
     Addresses:
       - ":20011"
     Enabled: true
-  UnlockWallet:
-    Path: "./wallets/node-wallet.json"
-    Password: "one"
+  Consensus:
+    Enabled: true
+    UnlockWallet:
+      Path: "./wallets/node-wallet.json"
+      Password: "one"


### PR DESCRIPTION
Turns out, we were still using obsolete configurations. I love https://github.com/nspcc-dev/neo-go/pull/3209 more and more.