### PR TITLE
ir: Fix boostrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,13 +112,13 @@ up/basic: up/bootstrap
 # Start bootstrap services
 .PHONY: up/bootstrap
 up/bootstrap: get vendor/hosts
+	@echo "NEOFS_IR_CONTRACTS_NEOFS="`./vendor/neo-go contract calc-hash -s NbUgTSFvPmsRxmGeWpuuGeJUoRoi6PErcM --in vendor/contracts/neofs/neofs_contract.nef -m vendor/contracts/neofs/config.json | grep -Eo '[a-fA-F0-9]{40}'` > services/ir/.ir.env
 	@for svc in $(START_BOOTSTRAP); do \
 		echo "$@ for service: $${svc}"; \
 		docker-compose -f services/$${svc}/docker-compose.yml up -d 2>&1 | tee -a docker-compose.err; \
 	done
 	@source ./bin/helper.sh
 	@docker exec main_chain neo-go wallet nep17 transfer --force --await --wallet-config /wallets/config.yml -r http://main-chain.neofs.devenv:30333 --from NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP  --to NbUgTSFvPmsRxmGeWpuuGeJUoRoi6PErcM --token GAS --amount 1000
-	@echo "NEOFS_IR_CONTRACTS_NEOFS="`./vendor/neo-go contract calc-hash -s NbUgTSFvPmsRxmGeWpuuGeJUoRoi6PErcM --in vendor/contracts/neofs/neofs_contract.nef -m vendor/contracts/neofs/config.json | grep -Eo '[a-fA-F0-9]{40}'` > services/ir/.ir.env
 	@./vendor/neo-go contract deploy --wallet-config wallets/config.yml --in vendor/contracts/neofs/neofs_contract.nef --manifest vendor/contracts/neofs/config.json --force --await -r http://main-chain.neofs.devenv:30333 [ true ffffffffffffffffffffffffffffffffffffffff [ 02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2 ] [ InnerRingCandidateFee 10000000000 WithdrawFee 100000000 ] ]
 	@NEOGO=vendor/neo-go WALLET=wallets/wallet.json CONFIG=wallets/config.yml ./bin/deposit.sh
 	@for f in ./services/storage/wallet*.json; do echo "Transfer GAS to wallet $${f}" && ./vendor/neofs-adm -c neofs-adm.yml morph refill-gas --storage-wallet $${f} --gas 10.0 --alphabet-wallets services/ir || die "Failed to transfer GAS to alphabet wallets"; done


### PR DESCRIPTION
```
can't get neofs script hash: expected string size of 40 got 0
```

We need to construct config before it is used. Did not allow first time run; also, it seems like it would not allow updating NeoFS contract.