### PR TITLE
ir/healthcheck: bootstrap with more reasonable check intervals

### DIFF
--- a/services/ir/docker-compose.yml
+++ b/services/ir/docker-compose.yml
@@ -26,9 +26,9 @@ services:
     command: [ "neofs-ir", "--config", "/etc/neofs/ir/config.yml" ]
     healthcheck:
       test: ["CMD", "/neofs-cli", "control", "healthcheck", "-c", "/cli-cfg.yml", "--endpoint", "${NEOFS_IR_CONTROL_GRPC_ENDPOINT}", "--ir"]
-      interval: 20s
+      interval: 1s
       timeout: 1s
-      retries: 5
+      retries: 300
       start_period: 5s
 
   ir-healthcheck:


### PR DESCRIPTION
We have included the NeoFS chain in IR app, and now some logic relies on block time (1s for the current dev-env). Most of the boostrap time, IR waits for a new block, which means that usually IR status changes once per second and nobody knows what exact second to pick, so 1s intervals looks more appropriate here. Also, 5 tries after 20s sleep may confuse with its `ERROR: for ir-healthcheck Container "blabla" is unhealthy.` output, cause most of the time 100s is not enough on my laptop.